### PR TITLE
Add option to dereference symlinks

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -197,7 +197,10 @@ export class TypeScriptPlugin {
 
       fs.copySync(
         path.resolve('node_modules'),
-        path.resolve(path.join(BUILD_FOLDER, 'node_modules'))
+        path.resolve(path.join(BUILD_FOLDER, 'node_modules')),
+        {
+          dereference: true,
+        }
       )
     } else {
       if (!fs.existsSync(outModulesPath)) {


### PR DESCRIPTION
Adds the `dereference` option to flatten symlinks when copying node_modules. This is useful in lerna environments which might symlink a node_module within the same project.

https://github.com/jprichardson/node-fs-extra/blob/HEAD/docs/copy-sync.md