### PR TITLE
Adjust all artifact paths

### DIFF
--- a/src/Serverless.d.ts
+++ b/src/Serverless.d.ts
@@ -9,6 +9,7 @@ declare namespace Serverless {
     }
 
     service: {
+      artifact: string
       provider: {
         name: string
       }

--- a/src/index.ts
+++ b/src/index.ts
@@ -223,33 +223,33 @@ export class TypeScriptPlugin {
       path.join(this.originalServicePath, SERVERLESS_FOLDER)
     )
 
-    if (this.options.function) {
-      const fn = service.functions[this.options.function]
-      fn.package.artifact = path.join(
-        this.originalServicePath,
-        SERVERLESS_FOLDER,
-        path.basename(fn.package.artifact)
-      )
-      return
-    }
-
-    if (service.package.individually) {
-      const functionNames = service.getAllFunctions()
-      functionNames.forEach(name => {
-        service.functions[name].package.artifact = path.join(
+    const functionNames = service.getAllFunctions()
+    functionNames.forEach(name => {
+      const fnPackage = service.functions[name].package
+      if (fnPackage.artifact) {
+        fnPackage.artifact = path.join(
           this.originalServicePath,
           SERVERLESS_FOLDER,
-          path.basename(service.functions[name].package.artifact)
+          path.basename(fnPackage.artifact)
         )
-      })
-      return
+      }
+    })
+
+    if (service.artifact) {
+      service.artifact = path.join(
+        this.originalServicePath,
+        SERVERLESS_FOLDER,
+        path.basename(service.artifact)
+      )
     }
 
-    service.package.artifact = path.join(
-      this.originalServicePath,
-      SERVERLESS_FOLDER,
-      path.basename(service.package.artifact)
-    )
+    if (service.package.artifact) {
+      service.package.artifact = path.join(
+        this.originalServicePath,
+        SERVERLESS_FOLDER,
+        path.basename(service.package.artifact)
+      )
+    }
   }
 
   async cleanup(): Promise<void> {


### PR DESCRIPTION
As the plugin manipulates `serverless.config.servicePath`, artifact paths need to be adjusted so that the state file matches the folder structure.

However, as other plugins (like the warmup plugin) might create additional functions, their artifacts also need adjustment.

I changed the code, so that it does not try to adjust the paths based on the configuration but eagerly looks in all possible places for artifact paths and replaces them if they exist.

Resolves #125 