### PR TITLE
Updates instruction to install source-map-support as regular dependency

### DIFF
--- a/README.md
+++ b/README.md
@@ -148,7 +148,7 @@ Options are:
 You can easily enable support for source-maps (making stacktraces easier to read) by installing and using the following plugin:
 
 ```sh
-yarn add --dev source-map-support
+yarn add source-map-support
 ```
 
 ```ts


### PR DESCRIPTION
source-map-support is imported inside the function, so I don't think it should be installed as a dev dependency.

If I install source-map-support as a dev dependency, and invoke the function on AWS Lambda, I get the following error `Runtime.ImportModuleError: Error: Cannot find module 'source-map-support/register'`

I'm new to Serverless and Typescript, so I might be completely mistaken here. Let me know.