### PR TITLE
Toggle features

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,6 +54,18 @@ The default `tsconfig.json` file used by the plugin looks like this:
 
 > Note 2: Don't confuse the [`tsconfig.json`](tsconfig.json) in this repository with the one mentioned above.
 
+You can also enable or disable functionalities in `serverless.yml`:
+
+```yml
+custom:
+  typescript:
+    run: true
+    offline: true # compile when running serverless offline
+    package: true # compile when doing serverless package
+    deploy: true # compile when doing serverless deploy
+    invoke: true # compile when doing serverless invoke
+```
+
 ### Including extra files
 
 All files from `package/include` will be included in the final build file. See [Exclude/Include](https://serverless.com/framework/docs/providers/aws/guide/packaging#exclude--include)

--- a/src/Serverless.d.ts
+++ b/src/Serverless.d.ts
@@ -15,6 +15,9 @@ declare namespace Serverless {
       functions: {
         [key: string]: Serverless.Function
       }
+      custom: {
+        [key: string]: any
+      }
       package: Serverless.Package
       getAllFunctions(): string[]
     }

--- a/src/index.ts
+++ b/src/index.ts
@@ -20,6 +20,8 @@ export class TypeScriptPlugin {
   constructor(serverless: Serverless.Instance, options: Serverless.Options) {
     this.serverless = serverless
     this.options = options
+    
+    this.hooks = {}
 
     if (serverless.service?.custom?.typescript?.run ?? true) {
       this.hooks['before:run:run'] = async () => {

--- a/src/index.ts
+++ b/src/index.ts
@@ -21,52 +21,66 @@ export class TypeScriptPlugin {
     this.serverless = serverless
     this.options = options
 
-    this.hooks = {
-      'before:run:run': async () => {
+    if (serverless.service?.custom?.typescript?.run ?? true) {
+      this.hooks['before:run:run'] = async () => {
         await this.compileTs()
         await this.copyExtras()
         await this.copyDependencies()
-      },
-      'before:offline:start': async () => {
-        await this.compileTs()
-        await this.copyExtras()
-        await this.copyDependencies()
-        this.watchAll()
-      },
-      'before:offline:start:init': async () => {
+      }
+    }
+
+    if (serverless.service?.custom?.typescript?.offline ?? true) {
+      this.hooks['before:offline:start'] = async () => {
         await this.compileTs()
         await this.copyExtras()
         await this.copyDependencies()
         this.watchAll()
-      },
-      'before:package:createDeploymentArtifacts': async () => {
+      }
+      this.hooks['before:offline:start:init'] = async () => {
         await this.compileTs()
-        await this.copyExtras()
-        await this.copyDependencies(true)
-      },
-      'after:package:createDeploymentArtifacts': async () => {
-        await this.cleanup()
-      },
-      'before:deploy:function:packageFunction': async () => {
-        await this.compileTs()
-        await this.copyExtras()
-        await this.copyDependencies(true)
-      },
-      'after:deploy:function:packageFunction': async () => {
-        await this.cleanup()
-      },
-      'before:invoke:local:invoke': async () => {
-        const emitedFiles = await this.compileTs()
         await this.copyExtras()
         await this.copyDependencies()
-        if (this.isWatching) {
-          emitedFiles.forEach(filename => {
-            const module = require.resolve(path.resolve(this.originalServicePath, filename))
-            delete require.cache[module]
-          })
+        this.watchAll()
+      }
+    }
+
+    if (serverless.service?.custom?.typescript?.package ?? true) {
+      this.hooks['before:package:createDeploymentArtifacts'] = async () => {
+        await this.compileTs()
+        await this.copyExtras()
+        await this.copyDependencies(true)
+      }
+      this.hooks['after:package:createDeploymentArtifacts'] = async () => {
+        await this.cleanup()
+      }
+    }
+
+    if (serverless.service?.custom?.typescript?.deploy ?? true) {
+      this.hooks['before:deploy:function:packageFunction'] = async () => {
+        await this.compileTs()
+        await this.copyExtras()
+        await this.copyDependencies(true)
+      }
+      this.hooks['after:deploy:function:packageFunction'] = async () => {
+        await this.cleanup()
+      }
+    }
+
+    if (serverless.service?.custom?.typescript?.invoke ?? true) {
+      this.hooks['before:invoke:local:invoke'] = async () => {
+        if (serverless.service?.custom?.typescript?.invoke ?? true) {
+          const emitedFiles = await this.compileTs()
+          await this.copyExtras()
+          await this.copyDependencies()
+          if (this.isWatching) {
+            emitedFiles.forEach(filename => {
+              const module = require.resolve(path.resolve(this.originalServicePath, filename))
+              delete require.cache[module]
+            })
+          }
         }
-      },
-      'after:invoke:local:invoke': () => {
+      }
+      this.hooks['after:invoke:local:invoke'] = () => {
         if (this.options.watch) {
           this.watchFunction()
           this.serverless.cli.log('Waiting for changes...')


### PR DESCRIPTION
Adds options to toggle certain features of this plugin.
In my setup, I package all my lambdas with `rollup`. However, this plugin is very convenient when running integration tests or when running with `serverless-offline`. It would be useful to be able to toggle off this plugin when doing deployments or packaging the application.
This PR implements this feature via `serverless.yml` custom configs.