### PR TITLE
fix: add all filenames discovered from parsed tsconfig options

### DIFF
--- a/src/watchFiles.ts
+++ b/src/watchFiles.ts
@@ -3,7 +3,7 @@ import { watchFile, unwatchFile, Stats} from 'fs'
 
 export function watchFiles(rootFileNames: string[], originalServicePath: string, cb: () => void) {
   const tsConfig = typescript.getTypescriptConfig(originalServicePath)
-  let watchedFiles = typescript.getSourceFiles(rootFileNames, tsConfig)
+  let watchedFiles = typescript.getSourceFiles(rootFileNames, tsConfig.options)
 
   watchedFiles.forEach(fileName => {
     watchFile(fileName, { persistent: true, interval: 250 }, watchCallback)
@@ -18,7 +18,7 @@ export function watchFiles(rootFileNames: string[], originalServicePath: string,
     cb()
 
     // use can reference not watched yet file or remove reference to already watched
-    const newWatchFiles =  typescript.getSourceFiles(rootFileNames, tsConfig)
+    const newWatchFiles =  typescript.getSourceFiles(rootFileNames, tsConfig.options)
     watchedFiles.forEach(fileName => {
       if (newWatchFiles.indexOf(fileName) < 0) {
         unwatchFile(fileName, watchCallback)

--- a/tests/typescript.getTypescriptConfig.test.ts
+++ b/tests/typescript.getTypescriptConfig.test.ts
@@ -3,9 +3,9 @@ import {getTypescriptConfig, makeDefaultTypescriptConfig} from '../src/typescrip
 describe('getTypescriptConfig', () => {
     it(`returns default typescript configuration if the one provided doesn't exist`, () => {
         expect(
-            getTypescriptConfig('/ciaone/my-folder'),
+            getTypescriptConfig('/ciaone/my-folder').options,
         ).toEqual(
-            makeDefaultTypescriptConfig()
+            makeDefaultTypescriptConfig().options
         )
     })
 })


### PR DESCRIPTION
Hi there,

First of all, congrats by your fantastic work. 

Trying to package a Serverless application created with Loopback 4 framework, the plugin is not considering to send to Typescript compiler all files, even if they are referenced to tsconfig file 'include'.

The tsconfig file parsed by the compiler shown in fileNames property all files detected by 'include'. I add there fileNames to plugin 'rootFileNames'.